### PR TITLE
Fix print:pd typo

### DIFF
--- a/p/print.ks
+++ b/p/print.ks
@@ -1,5 +1,5 @@
 { parameter n. local _ is lex(
 "pr", {parameter n,s. until s:length >= n {set s to s+" ".} return s.},
 "pl", {parameter n,s. until s:length >= n {set s to " "+s.} return s.},
-"pd", {parameter n,v. return _:pl(n,""+round(v)).},).
+"pd", {parameter n,v. return _:pl(n,""+round(v)).}).
 export(n, _).}


### PR DESCRIPTION
extra comma not removed during copy-pasta cooking.